### PR TITLE
Bus Player for controlling Audio Buses

### DIFF
--- a/addons/mpf-gmc/scripts/audio/GMCBus.gd
+++ b/addons/mpf-gmc/scripts/audio/GMCBus.gd
@@ -197,6 +197,12 @@ func is_resource_playing(filepath: String) -> bool:
 			return true
 	return false
 
+func pause(settings: Dictionary) -> void:
+	# Track player uses a universal "fade" rather than fade_in or fade_out
+	var fade_out = settings.get("fade")
+	for channel in self.channels:
+		channel.pause_with_settings({"fade_out": fade_out})
+
 func stop(key: String, settings: Dictionary) -> void:
 	var is_bus_playing := false
 	# Find the channel playing this file
@@ -216,7 +222,7 @@ func stop_all(fade_out: float = 1.0) -> void:
 	self.clear_queue()
 	for channel in self.channels:
 		if channel.playing and not channel.get_meta("is_stopping", false):
-			channel.stop_with_settings({ "fade_out": fade_out }, "stop_all")
+			channel.stop_with_settings({"action": "stop_all", "fade_out": fade_out })
 
 func _abort_ducking_check():
 	# However, if nothing is playing and there's a duck, kill it

--- a/addons/mpf-gmc/scripts/audio/GMCBus.gd
+++ b/addons/mpf-gmc/scripts/audio/GMCBus.gd
@@ -198,10 +198,12 @@ func is_resource_playing(filepath: String) -> bool:
 	return false
 
 func pause(settings: Dictionary) -> void:
-	# Track player uses a universal "fade" rather than fade_in or fade_out
-	var fade_out = settings.get("fade")
 	for channel in self.channels:
-		channel.pause_with_settings({"fade_out": fade_out})
+		channel.pause_with_settings(settings)
+
+func unpause(settings: Dictionary) -> void:
+	for channel in self.channels:
+		channel.unpause_with_settings(settings)
 
 func stop(key: String, settings: Dictionary) -> void:
 	var is_bus_playing := false

--- a/addons/mpf-gmc/scripts/audio/GMCChannel.gd
+++ b/addons/mpf-gmc/scripts/audio/GMCChannel.gd
@@ -38,6 +38,8 @@ func play_with_settings(settings: Dictionary) -> AudioStream:
 	self.log.debug("playing %s (%s) on %s with settings %s", [self.stream.resource_path, self.stream, self, settings])
 	self.stream.set_meta("context", settings.context)
 	self.stream.set_meta("key", settings.key)
+	self.stream_paused = false
+
 	var start_at: float = settings["start_at"] if settings.get("start_at") else 0.0
 	var fade_in: float = settings["fade_in"] if settings.get("fade_in") else 0.0
 	if settings.get("fade_out"):
@@ -105,12 +107,30 @@ func clear():
 	self.volume_db = 0.0
 	self.remove_meta("tween")
 	self.remove_meta("is_stopping")
+	self.stream_paused = false
 	self.markers = []
 	self.stream = null
 	set_process(false)
 
-func stop_with_settings(settings: Dictionary = {}, action: String = "stop") -> void:
-	if settings.get("action") == "loop_stop":
+func pause_with_settings(settings: Dictionary = {}) -> void:
+	if not self.stream or not self.playing or stream.get_meta("is_stopping", false):
+		return
+	var fade_out = settings.get("fade_out")
+	if not fade_out:
+		self.stream_paused = true
+		self.log.info("%s is paused: stream_paused is %s, self.playing is %s", [self, self.stream_paused, self.playing])
+		return
+
+	var tween = self.create_tween()
+	tween.tween_property(self, "volume_db", -80.0, fade_out) \
+		.set_trans(Tween.TRANS_QUINT).set_ease(Tween.EASE_IN)
+	tween.finished.connect(self._on_fade_complete.bind(tween, "pause"))
+	self.tweens.append(tween)
+	self.set_meta("tween", tween)
+
+func stop_with_settings(settings: Dictionary = {}) -> void:
+	var action = settings.get("action", "stop")
+	if action == "loop_stop":
 		# The position is reset when the loop mode changes, so store it first
 		var pos: float = self.get_playback_position()
 		self.stream.loop_mode = 0
@@ -142,6 +162,8 @@ func _on_fade_complete(tween, action) -> void:
 		self.clear()
 	elif action == "play":
 		self.log.debug("Fade in to %0.2f complete on channel %s", [self.volume_db, self])
+	elif action == "pause":
+		self.stream_paused = true
 
 func _on_loop() -> void:
 	var loops_remaining = self.stream.get_meta("loops_remaining") - 1

--- a/addons/mpf-gmc/scripts/bcp_server.gd
+++ b/addons/mpf-gmc/scripts/bcp_server.gd
@@ -304,6 +304,8 @@ func _thread_poll(_userdata=null) -> void:
 						call_deferred("on_ball_end")
 					"ball_start":
 						call_deferred("on_ball_start", message.ball, message.player_num)
+					"buses_play":
+						call_deferred("deferred_mc", "play", message)
 					"goodbye":
 						_send("goodbye")
 						call_deferred("stop")

--- a/addons/mpf-gmc/scripts/media.gd
+++ b/addons/mpf-gmc/scripts/media.gd
@@ -38,6 +38,9 @@ func register_window(inst: Node) -> void:
 func play(payload: Dictionary) -> void:
 	var command = payload.name
 	match command:
+		"buses_play":
+			print("BUS PLAYER PAYLOAD: %s" % payload)
+			self.sound.play_bus(payload)
 		"slides_play":
 			self.window.play_slides(payload)
 		"widgets_play":

--- a/addons/mpf-gmc/scripts/media.gd
+++ b/addons/mpf-gmc/scripts/media.gd
@@ -39,7 +39,6 @@ func play(payload: Dictionary) -> void:
 	var command = payload.name
 	match command:
 		"buses_play":
-			print("BUS PLAYER PAYLOAD: %s" % payload)
 			self.sound.play_bus(payload)
 		"slides_play":
 			self.window.play_slides(payload)

--- a/addons/mpf-gmc/scripts/sound_player.gd
+++ b/addons/mpf-gmc/scripts/sound_player.gd
@@ -112,6 +112,20 @@ func play_sounds(s: Dictionary) -> void:
 					channel.stop_with_settings()
 		bus.play(file, settings)
 
+func play_bus(s: Dictionary) -> void:
+	for bus_name in s.settings.keys():
+		assert(bus_name in self.buses, "Bus name %s is not a valid audio bus." % bus_name)
+		var bus = self.buses[bus_name]
+		var settings = s.settings[bus_name]
+
+		match settings["action"]:
+			"pause":
+				bus.pause({"fade_out": settings.get("fade")})
+			# "unpause":
+			# 	bus.unpause_with_settings({"fade_in": settings.get("fade")})
+			"stop":
+				bus.stop_all({"fade_out": settings.get("fade")})
+
 # Not currently implemented anywhere
 func stop_all(fade_out: float = 1.0) -> void:
 	self.log.debug("STOP ALL called with fadeout of %s" , fade_out)

--- a/addons/mpf-gmc/scripts/sound_player.gd
+++ b/addons/mpf-gmc/scripts/sound_player.gd
@@ -121,10 +121,10 @@ func play_bus(s: Dictionary) -> void:
 		match settings["action"]:
 			"pause":
 				bus.pause({"fade_out": settings.get("fade")})
-			# "unpause":
-			# 	bus.unpause_with_settings({"fade_in": settings.get("fade")})
+			"unpause":
+				bus.unpause({"fade_in": settings.get("fade")})
 			"stop":
-				bus.stop_all({"fade_out": settings.get("fade")})
+				bus.stop_all(settings.get("fade", 0.0))
 
 # Not currently implemented anywhere
 func stop_all(fade_out: float = 1.0) -> void:


### PR DESCRIPTION
This PR introduces support for `bus_player` commands from MPF, akin to the `track_player` configs of MPF 0.57.

Three actions are supported: `pause`, `unpause`, and `stop`. 

```

bus_player:
  delay_pause:
    music:
      action: pause
      fade: 2s
  delay_resume:
    music:
      action: unpause
      fade: 2s
  delay_stop:
    music:
      action: stop
      fade: 1s
```

Note that when a bus pauses, the channel is no longer considered active and may be replaced by a new sound request. To ensure proper isolation of sound files on a bus, use a unique bus for those sounds.