### PR TITLE
Support action: animation for slide and widget player

### DIFF
--- a/addons/mpf-gmc/classes/mpf_scene_base.gd
+++ b/addons/mpf-gmc/classes/mpf_scene_base.gd
@@ -82,6 +82,9 @@ func process_action(child_name: String, children: Array, action: String, setting
 		"update":
 			if child:
 				child.action_update(settings, kwargs)
+		"animation":
+			if child:
+				child.action_animation(settings, kwargs)
 		"method":
 			if child and child.has_method(settings.method):
 				var callable = Callable(child, settings.method)
@@ -102,6 +105,20 @@ func action_queue(_action: String, _slide_name: String, _settings: Dictionary, _
 func action_update(settings: Dictionary, kwargs: Dictionary = {}) -> void:
 	for c in self._updaters:
 		c.update(settings, kwargs)
+
+func action_animation(settings: Dictionary, kwargs: Dictionary = {}) -> void:
+	if not self.animation_player:
+		self.log.error("No animation_player property defined. Please attach an AnimationPlayer node.")
+		return
+	var anim_name: String = settings.get("animation")
+	if not self.animation_player.has_animation(anim_name):
+		self.log.error("No animation named '%s'", anim_name)
+		return
+	# If this animation is already going, restart it
+	if self.animation_player.assigned_animation == anim_name and settings.get("from_start", true):
+		self.animation_player.seek(0)
+	self.animation_player.play(anim_name,
+		settings.get("custom_blend", -1), settings.get("custom_speed", 1), settings.get("from_end", false))
 
 func register_updater(node: Node) -> void:
 	if self._updaters.find(node) == -1:


### PR DESCRIPTION
This PR adds support for `action: animation` on slide and widget players to trigger animations on an MPFSlide or MPFWidget's attached `animation_player` node.

The syntax looks like this:
```
slide_player:
  item_highlighted:
    attract:
      action: animation
      animation: item_highlight_anim
```

In this example, the _item_highlighted_ event would trigger the _attract.tscn_ slide's `AnimationPlayer` node to play its "item_highlight_anim" animation. 

This change is inspired by @albano353's  carousel animation proposal in #23, taking that idea and extracting it to be broadly applicable. All `MPFSlide` and `MPFWidget` nodes already support an attached `AnimationPlayer`(for enter/exit/active animations) so the change to support the `action: animation` functionality is pretty simple.

Tested on a local game project using the above code snippet.

*Note: this change requires a corresponding config_spec.yaml change, which has been merged to the MPF 0.80.x branch. Please pull the latest MPF to test.*

![in we go!](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMW83dGZoOXdqZGdmdm41NHhtM2QxcG1kZmlxbzkwMW12aXRvNHpjdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oPFYC7dB0J9pm/giphy.gif)

