### PR TITLE
New MPFConditional type ACTIVE_SLIDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### New Features
 
+* New `MPFConditional` variable type `ACTIVE_SLIDE` to match conditions based on the active slide (most likely the variable name "name" to match the name of the active slide). Will automatically re-evaluate when the slides change.
+
 * New slide_player / widget_player `action: animation` to play an animation from a triggering event. Include `animation: <animation_name>` in the player config to specify which animation to play. The corresponding MPFSlide/MPFWidget must have an `animation_player` node assigned in the Inspector panel.
 
 ```
@@ -28,6 +30,10 @@ slide_player:
 * Fix WAV audio files not looping properly when not explicitly re-imported with loop metadata
 * Fix `MPFConditional` not checking min/max players when conditional value changes
 * Fix `MPFTextInput` not respecting `max_length` parameter during text input (e.g. high score entry)
+
+### Other Changes
+
+* The special slide target `_overlay` now has an explicit z-index of 4000 to ensure it is positioned above other slides, even if they have a z-index defined (e.g. UI slides lower-priority to avoid being "active" but still rendered on top of the "active" slide). The maximum z-index is 4096 so other slides can still supersede the overlay slide if desired.
 
 ## 0.1.3
 *24 January 2025*

--- a/addons/mpf-gmc/classes/const.gd
+++ b/addons/mpf-gmc/classes/const.gd
@@ -18,5 +18,7 @@ enum VariableType {
 	## Player 3
 	PLAYER_3,
 	## Player 4
-	PLAYER_4
+	PLAYER_4,
+	## The currently active slide name
+	ACTIVE_SLIDE
 }

--- a/addons/mpf-gmc/scripts/utilities.gd
+++ b/addons/mpf-gmc/scripts/utilities.gd
@@ -25,6 +25,16 @@ static func find_parent_slide(n: Node, allow_widget: bool = false):
 static func find_parent_slide_or_widget(n: Node):
 	return find_parent_slide(n, true)
 
+static func find_parent_display(n: Node):
+	var parent = n
+	while parent:
+		if parent is MPFDisplay:
+			return parent
+		parent = parent.get_parent()
+	if not parent:
+		printerr("No parent display found for %s" % n.name)
+		return
+
 static func find_parent_window(n: Node):
 	var parent = n
 	while parent:


### PR DESCRIPTION
This PR extends the `MPFConditional` node to offer a new comparator target for conditional evaluations: `ACTIVE_SLIDE`.

When selected, conditions can be run against the active slide (most likely against "name", but could be against context, priority, or key). This is ideal for widgets that may have different layouts or positions based on the underlying slide (e.g. full-size overlay on base slide but small popup on other slides).

The condition will re-evaluate any time the slide stack changes and a new slide becomes active.

Tested on a local project and works well. Godot automatically capitalizes node names so this code includes a (dev-only) case sensitivity check.

This also fixes a bug where the conditional would evaluate itself on initialization, which is unnecessary because the slide initializes all widgets when it attaches them. Conditions were being evaluated twice back-to-back, causing unnecessary work on the CPU.

![Slide, my pretty!](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2gxeTRqa2Q3dTFocGZ2cWdtdGF2NGMxb2dmNm5nbTV6am1zODZ2eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4KibK3JwaVo0CjDO/giphy.gif) 