### PR TITLE
Add default tilt and warning slides

### DIFF
--- a/addons/mpf-gmc/slides/tilt.tscn
+++ b/addons/mpf-gmc/slides/tilt.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=3 format=3 uid="uid://k06kokgbf56c"]
+
+[ext_resource type="Script" path="res://addons/mpf-gmc/classes/mpf_slide.gd" id="1_gc685"]
+[ext_resource type="Script" path="res://addons/mpf-gmc/classes/mpf_variable.gd" id="2_tuxrv"]
+
+[node name="Tilt" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gc685")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 0
+offset_right = 2880.0
+offset_bottom = 864.0
+color = Color(0, 0, 0, 1)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -110.0
+offset_top = -137.0
+offset_right = 110.0
+offset_bottom = 137.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MPFVariable - Text" type="Label" parent="CenterContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 250
+text = "TILT"
+script = ExtResource("2_tuxrv")
+variable_type = 1
+variable_name = "text"
+template_string = "%s"


### PR DESCRIPTION
Creating these slides was a little tricky - I created a new slide (vs duplicating) with MPFSlide root, then I hand-added the colorrect and center and label, but that caused wrongly-offset rendering. So I hand-copied the tscn config text for the root node and centering node, and that seemed to make it render correctly, without being hardcoded to my system. I hope. Definitely worth your testing/poking around.

I have locally tested that these slides display and expire as expected (when running with the PR MPF) and that the user providing their own slides with the same name does cause those user slides to display instead.

This PR accompanied by: https://github.com/missionpinball/mpf/pull/1885 and documented by https://github.com/missionpinball/mpf-docs/pull/585