### PR TITLE
Tweaks for high_score default slide

### DIFF
--- a/addons/mpf-gmc/slides/high_score.tscn
+++ b/addons/mpf-gmc/slides/high_score.tscn
@@ -62,4 +62,4 @@ text = "Player N:"
 script = ExtResource("3_hewrl")
 variable_type = 1
 variable_name = "player_num"
-template_string = "Player %s:"
+template_string = "Player %d:"

--- a/addons/mpf-gmc/slides/high_score.tscn
+++ b/addons/mpf-gmc/slides/high_score.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://lqeoxevsy0ex"]
+[gd_scene load_steps=4 format=3 uid="uid://lqeoxevsy0ex"]
 
 [ext_resource type="Script" path="res://addons/mpf-gmc/classes/mpf_slide.gd" id="1_adeqt"]
 [ext_resource type="Script" path="res://addons/mpf-gmc/classes/mpf_text_input.gd" id="2_6uslk"]
+[ext_resource type="Script" path="res://addons/mpf-gmc/classes/mpf_variable.gd" id="3_hewrl"]
 
 [node name="HighScore" type="Control"]
 layout_mode = 3
@@ -17,19 +18,48 @@ offset_bottom = 246.0
 
 [node name="MPFTextInput" type="HFlowContainer" parent="." node_paths=PackedStringArray("display_node")]
 layout_mode = 0
-offset_left = 720.0
-offset_top = 419.0
-offset_right = 1259.0
-offset_bottom = 605.0
+offset_left = 329.0
+offset_top = 551.0
+offset_right = 868.0
+offset_bottom = 632.0
+scale = Vector2(4, 4)
 script = ExtResource("2_6uslk")
 grid_width = 30
 display_node = NodePath("../RichTextLabel")
 
 [node name="RichTextLabel" type="RichTextLabel" parent="."]
 layout_mode = 0
-offset_left = 664.0
-offset_top = 72.0
-offset_right = 1264.0
-offset_bottom = 332.0
+offset_left = 663.0
+offset_top = 258.0
+offset_right = 1284.0
+offset_bottom = 345.0
+scale = Vector2(3.5, 3.5)
 theme_override_font_sizes/normal_font_size = 60
 bbcode_enabled = true
+text = "[pulse freq=3.0 color=#ff00ffff ease=-1.0]A[/pulse]"
+
+[node name="event_award" type="Label" parent="."]
+layout_mode = 0
+offset_left = 758.0
+offset_top = 61.0
+offset_right = 2046.0
+offset_bottom = 231.0
+theme_override_font_sizes/font_size = 100
+text = "Award Name"
+horizontal_alignment = 1
+script = ExtResource("3_hewrl")
+variable_type = 1
+variable_name = "award"
+
+[node name="event_player" type="Label" parent="."]
+layout_mode = 0
+offset_left = 152.0
+offset_top = 330.0
+offset_right = 595.0
+offset_bottom = 476.0
+theme_override_font_sizes/font_size = 100
+text = "Player N:"
+script = ExtResource("3_hewrl")
+variable_type = 1
+variable_name = "player_num"
+template_string = "Player %s:"

--- a/addons/mpf-gmc/slides/high_score_award.tscn
+++ b/addons/mpf-gmc/slides/high_score_award.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=3 format=3 uid="uid://fcdwlg4u44ft"]
+
+[ext_resource type="Script" uid="uid://6mdcui7wkc47" path="res://addons/mpf-gmc/classes/mpf_slide.gd" id="1_8uavx"]
+[ext_resource type="Script" uid="uid://cm7sg7wq6hq8s" path="res://addons/mpf-gmc/classes/mpf_variable.gd" id="2_8uavx"]
+
+[node name="HighScoreAward" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("1_8uavx")
+
+[node name="MPFVariable - Award" type="Label" parent="."]
+layout_mode = 0
+offset_left = 236.0
+offset_top = -11.0
+offset_right = 941.0
+offset_bottom = 194.0
+theme_override_font_sizes/font_size = 150
+text = "Award!"
+horizontal_alignment = 1
+script = ExtResource("2_8uavx")
+variable_type = 1
+variable_name = "award"
+metadata/_custom_type_script = "uid://cm7sg7wq6hq8s"
+
+[node name="MPFVariable - Player Name" type="Label" parent="."]
+layout_mode = 0
+offset_left = 236.0
+offset_top = 187.0
+offset_right = 941.0
+offset_bottom = 392.0
+theme_override_font_sizes/font_size = 150
+text = "NO1"
+horizontal_alignment = 1
+script = ExtResource("2_8uavx")
+variable_type = 1
+variable_name = "player_name"
+metadata/_custom_type_script = "uid://cm7sg7wq6hq8s"
+
+[node name="MPFVariable - Value" type="Label" parent="."]
+layout_mode = 0
+offset_left = 225.0
+offset_top = 390.0
+offset_right = 930.0
+offset_bottom = 595.0
+theme_override_font_sizes/font_size = 150
+text = "1,000,000"
+horizontal_alignment = 1
+script = ExtResource("2_8uavx")
+variable_type = 1
+variable_name = "value"
+comma_separate = true
+metadata/_custom_type_script = "uid://cm7sg7wq6hq8s"


### PR DESCRIPTION
I added event variable text to slide for high score player number and award name. I noticed there's a blank label present that doesn't seem to do anything, but I didn't delete it. I also did not try to do any nice alignment or layout arrangement, but I'm happy to if you can point me at a pattern to replicate. I did scale up some of the existing elements because they felt so tiny!

![Screenshot 2025-04-22 215559](https://github.com/user-attachments/assets/718d7010-fdb3-4dd7-85f8-eb8da94f7f1b)
Maybe I could add a default background colorrect as well