### PR TITLE
GMC Text Input reset on submit

### DIFF
--- a/addons/mpf-gmc/classes/mpf_text_input.gd
+++ b/addons/mpf-gmc/classes/mpf_text_input.gd
@@ -121,6 +121,11 @@ func _on_select():
 			# Strip whitespace and escape the name before sending
 			var final_text := current_text.strip_edges().uri_encode()
 			MPF.server.send_event("text_input_%s_complete&text=%s" % [self.input_name, final_text])
+
+			# once the value is submitted, clear the text and reset selected letter to first option
+			current_text = ""
+			self._update_preview("")
+			self._focus_item(0)
 			return
 		_:
 			new_text += selection.text


### PR DESCRIPTION
Reset the text on the high score text input as soon as the value is submitted. The existing behavior does not explicitly clear out between players, so if P1 and P2 both get high scores, the second player to enter will have to DEL the existing letters first.