### PR TITLE
Treat S* process state on *nix as alive to avoid false warning

### DIFF
--- a/addons/mpf-gmc/scripts/process.gd
+++ b/addons/mpf-gmc/scripts/process.gd
@@ -111,7 +111,7 @@ func _check_mpf():
 	if not output:
 		return
 	var result = output[0].strip_edges()
-	if result  == "Z":
+	if result == "Z":
 		mpf_attempts += 1
 		if mpf_attempts <= MAX_MPF_ATTEMPTS:
 			self.log.info("MPF Failed to Start, Retrying (%d/%d)", [mpf_attempts, MAX_MPF_ATTEMPTS])
@@ -119,7 +119,8 @@ func _check_mpf():
 		else:
 			self.mpf.server.set_status(self.mpf.server.ServerStatus.ERROR)
 			self.mpf_spawned.emit(-1)
-	elif result == "Ss":
+	elif result.begins_with("S"):
+		# Treat "S", "Ss", "Sl" etc. as alive/sleeping
 		self.mpf_spawned.emit(1)
 	else:
 		self.log.warning("Unknown process status '%s'", result)


### PR DESCRIPTION
On *nix systems, MPF reports state "S" (sleeping) immediately after launch.
The current script only recognises "Ss" as alive, so a normal "S" triggers:

    WARNING : GMCProcess : Unknown process status 'S'

This patch treats any "S*" state (S, Ss, Sl, etc.) as alive and emits mpf_spawned=1 accordingly.