### PR TITLE
update version to 1.0.0 and require MPF 0.80.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # MPF-GMC Changelog
 
+## 1.0.0
+*25 April 2026*
+
+### New Features
+
+Full release to match MPF 0.80.0!
+
+### Requirements
+
+MPF 0.80.0 requires MPF-GMC 1.0.0 at minimum.
+
+### Improvements
+* reduce \*nix process monitoring warnings due to process state
+
+### Bug Fixes
+* Changing settings in the service menu actually makes the changes now
+
+
 ## 0.1.6
 *14 December 2025*
 
@@ -22,7 +40,6 @@
 * Fix sound hook to properly use `events_when_played`, not `events_when_started`
 * Fix missing light and coil names in service mode
 * Fix exports missing resources due to global MPF missing during export
-
 
 ## 0.1.5
 *24 July 2025*

--- a/addons/mpf-gmc/mpf_gmc.gd
+++ b/addons/mpf-gmc/mpf_gmc.gd
@@ -9,7 +9,7 @@ extends LoggingNode
 
 const CONFIG_PATH = "res://gmc.cfg"
 const LOCAL_CONFIG_PATH = "user://gmc.local.cfg"
-const MPF_MIN_VERSION = "0.80.0.dev10"
+const MPF_MIN_VERSION = "0.80.0"
 
 var game
 var media

--- a/addons/mpf-gmc/plugin.cfg
+++ b/addons/mpf-gmc/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot MC"
 description="A Media Controller for the Mission Pinball Framework (MPF)"
 author="Mission Pinball Framework"
-version="0.1.6"
+version="1.0.0"
 script="mpf_gmc_editor.gd"


### PR DESCRIPTION
I think upgrading to 1.0.0 will encourage our userbase. I think it also gives a good opportunity to reset the numbering:

`major.minor.patch`, where ideally major Godot or MPF breaking changes rev the major, random feature upgrades rev the minor, and bugfixes rev the patch.