### PR TITLE
Clean up temporary MPFGMC instance during export

### DIFF
--- a/addons/mpf-gmc/editor/mpf_gmc_export.gd
+++ b/addons/mpf-gmc/editor/mpf_gmc_export.gd
@@ -19,6 +19,13 @@ func _export_begin(features: PackedStringArray, is_debug: bool, path: String, fl
 	var traversal_data = PackedDataContainer.new()
 	traversal_data.pack(traversal)
 	ResourceSaver.save(traversal_data, "res://_media.res")
+	_cleanup_export_mpf(mpf)
+
+func _cleanup_export_mpf(mpf: MPFGMC) -> void:
+	for child in [mpf.server, mpf.media, mpf.process, mpf.game, mpf.util]:
+		if is_instance_valid(child):
+			child.free()
+	mpf.free()
 
 func _export_end() -> void:
 	# Remove the temporary media traversal file


### PR DESCRIPTION
## Summary

Fix an export-time leak in the GMC export plugin.

During export, creates a temporary instance to generate media traversal data. That temporary instance also creates helper nodes (server, media, process, game, util) that were not being freed before export shutdown.

## Change

Add explicit cleanup for the temporary export-time instance and its helper nodes after traversal data is saved.

## Result

Godot export now completes without the warning caused by the temporary exporter instance.

## Scope

This only affects the editor export path. Runtime game behavior is unchanged.