### PR TITLE
add mpf player filter to split out player display rules from mpfvariable

### DIFF
--- a/addons/mpf-gmc/classes/mpf_player_filter.gd
+++ b/addons/mpf-gmc/classes/mpf_player_filter.gd
@@ -1,0 +1,47 @@
+extends Node2D
+class_name MPFPlayerFilter
+
+## Shows or hides itself (and thus children) based on player counts.
+
+## If set, this node will only render if the number of players is greater than or equal to this value.
+@export var min_players: int
+## If set, this node will only render if the number of players is less than or equal to this value.
+@export var max_players: int
+## If set, this node will only render if the current player is the set number.
+@export var player_number: int = 0
+
+var known_player_count: int
+
+func _ready() -> void:
+	self.known_player_count = MPF.game.num_players
+	# Always listen for player count changes
+	MPF.game.connect("player_added", self._update_known_players)
+	self._update_visibility()
+
+func _should_show() -> bool:
+	if self.player_number > 0:
+		var current_player_number = MPF.game.player.get("number")
+		if not current_player_number:
+			MPF.log.error("MPFPlayerFilter '%s' can only use the player_number setting during game modes.", self.name)
+			return false # fast exit and hide when errored
+
+		# always hide when mismatch
+		if self.player_number != MPF.game.player.get('number'):
+			return false
+
+	if min_players > 0 and min_players > self.known_player_count:
+		return false
+	if max_players > 0 and self.known_player_count > max_players:
+		return false
+	return true
+
+func _update_known_players(total_players: int) -> void:
+	self.known_player_count = total_players
+	self._update_visibility()
+
+func _update_visibility() -> void:
+	if self._should_show():
+		self.show()
+	else:
+		self.hide()
+

--- a/addons/mpf-gmc/classes/mpf_player_filter.gd
+++ b/addons/mpf-gmc/classes/mpf_player_filter.gd
@@ -13,10 +13,9 @@ class_name MPFPlayerFilter
 var known_player_count: int
 
 func _ready() -> void:
-	self.known_player_count = MPF.game.num_players
+	self._update_known_players(MPF.game.num_players)
 	# Always listen for player count changes
 	MPF.game.connect("player_added", self._update_known_players)
-	self._update_visibility()
 
 func _should_show() -> bool:
 	if self.player_number > 0:

--- a/addons/mpf-gmc/classes/mpf_player_filter.gd.uid
+++ b/addons/mpf-gmc/classes/mpf_player_filter.gd.uid
@@ -1,0 +1,1 @@
+uid://kjf4f6wwcwa6

--- a/addons/mpf-gmc/classes/mpf_variable.gd
+++ b/addons/mpf-gmc/classes/mpf_variable.gd
@@ -29,7 +29,7 @@ const numbered_players = [VariableType.PLAYER_1, VariableType.PLAYER_2, Variable
 
 var var_template: String = "%s"
 ## Track the player number this variable applies to
-var player_number: int = -1
+var numbered_players_player_number: int = -1
 ## Track the initial text to know whether it needs to be initialized empty
 var _initial_text: String = ""
 
@@ -138,7 +138,7 @@ func _on_player_added(total_players: int) -> void:
 	elif max_players > 0 and total_players > max_players:
 		self.hide()
 	# If this player number exceeds the number of players, don't show
-	elif self.player_number > total_players:
+	elif self.numbered_players_player_number > total_players:
 		self.hide()
 	else:
 		# TODO: There is a gap here where a min/max var that applies to the current
@@ -152,13 +152,13 @@ func _calculate_player_value() -> bool:
 		MPF.log.warning("MPFVariable '%s' is a player variable and should only exist in game modes.", self.name)
 		return false
 	if variable_type == VariableType.CURRENT_PLAYER:
-		self.player_number = mpf_player_num
+		self.numbered_players_player_number = mpf_player_num
 	elif variable_type in numbered_players:
-		self.player_number = numbered_players.find(variable_type) + 1
-	var is_current_player = self.player_number == MPF.game.player.get('number')
+		self.numbered_players_player_number = numbered_players.find(variable_type) + 1
+	var is_current_player = self.numbered_players_player_number == MPF.game.player.get('number')
 	if is_current_player:
 		self.update_text(MPF.game.player.get(self.variable_name))
 		return true
-	elif MPF.game.players.size() >= self.player_number:
-		self.update_text(MPF.game.players[self.player_number - 1].get(self.variable_name))
+	elif MPF.game.players.size() >= self.numbered_players_player_number:
+		self.update_text(MPF.game.players[self.numbered_players_player_number - 1].get(self.variable_name))
 	return false


### PR DESCRIPTION
I really want the filtering features of MPFVariable without having to actually check a variable. I also added a player_number setting that only shows the node to that player number, which is a little different than MPFVariable with a player # as the lookup type.

This could be ported to MPFVariable, but IMO I'd push MPFVariable to actually extend this base class (or force developers to split filtering and content into different nodes.)