### PR TITLE
Fix MPFCarousel showing nothing when it is created after its highlight is posted

### DIFF
--- a/addons/mpf-gmc/classes/mpf_carousel.gd
+++ b/addons/mpf-gmc/classes/mpf_carousel.gd
@@ -27,6 +27,13 @@ func _ready():
 	if not carousel_name in MPF.game.active_modes and OS.has_feature("debug"):
 		self.log.warning("No active mode '%s', carousel will not function until that mode is active.", [carousel_name])
 	MPF.server.carousel_item_highlighted.connect(self._on_item_highlighted)
+	# MPF posts a carousel's highlight once when its mode starts. If this node
+	# was created after that emit (for example when a mode that owns a carousel
+	# stops and starts again), the signal was already missed and no child would
+	# show until the next advance. Replay the last buffered highlight so the
+	# current item appears immediately on mount.
+	if MPF.server.last_carousel_highlight.has(carousel_name):
+		self._on_item_highlighted(MPF.server.last_carousel_highlight[carousel_name])
 	self.log.debug("Carousel active and waiting for carousel_item_highlighted events for 'carousel=%s'.", carousel_name)
 
 func _on_item_highlighted(payload: Dictionary) -> void:

--- a/addons/mpf-gmc/scripts/bcp_server.gd
+++ b/addons/mpf-gmc/scripts/bcp_server.gd
@@ -31,6 +31,13 @@ var port := 5050
 var poll_fps: int = 120
 # The current status of the server
 var status: ServerStatus = ServerStatus.IDLE
+# The most recent carousel_item_highlighted payload, keyed by carousel name.
+# MPF posts a carousel's highlight once when its mode starts. If the MPFCarousel
+# node is created after that emit (for example when a mode that owns a carousel
+# stops and starts again), the one-shot signal is missed and the carousel shows
+# nothing until the next advance. Keeping the last payload lets a freshly
+# created carousel replay it from _ready().
+var last_carousel_highlight := {}
 
 # A library of static methods for parsing the incoming BCP data
 var _bcp_parse = preload("bcp_parse.gd")
@@ -347,6 +354,11 @@ func _thread_poll(_userdata=null) -> void:
 					_send("hello")
 					call_deferred("_on_connect", message)
 				"carousel_item_highlighted":
+					# Buffer the latest highlight per carousel so a node created
+					# after this one-shot emit can replay it from _ready(). See
+					# last_carousel_highlight above.
+					if message.has("carousel"):
+						last_carousel_highlight[message.carousel] = message
 					carousel_item_highlighted.emit.call_deferred(message)
 				"list_coils":
 					service.emit.call_deferred(message)


### PR DESCRIPTION
`carousel_item_highlighted` is posted once when a carousel's mode starts (direction `None`), and `MPFCarousel` only learns its current item from that signal, which it connects to in `_ready()`.

If the carousel node is created after that emit, the signal is already gone by the time `_ready()` runs, so the carousel never shows any of its children until the next advance (a next/previous navigation) posts a fresh highlight. The reliable way to reproduce it is restarting a mode that owns a carousel: the mode stops, the slide and its carousel are freed, the mode starts again and posts the highlight, then the new carousel node mounts a moment later having missed it. On screen you get the slide background with no carousel item on it.

The fix buffers the most recent `carousel_item_highlighted` payload per carousel in the BCP server and replays it from `MPFCarousel._ready()` if one is present. On a cold start the buffer is empty (or identical to the live signal), so behavior is unchanged; on a re-entry the carousel paints its current item right away instead of coming up blank.

Two changes:
- `bcp_server.gd` keeps `last_carousel_highlight` keyed by carousel name, set just before the existing emit.
- `mpf_carousel.gd` replays the buffered highlight after connecting its handler.

I confirmed both the failure and the fix with a headless test that forces the two orderings: mounting the carousel before the highlight shows the item as before, and mounting it after leaves every child hidden without the patch and shows the right item with it. No config or API changes.