### PR TITLE
Fix the BCP reader thread dying silently after a period of idle polling

### DIFF
--- a/addons/mpf-gmc/scripts/bcp_server.gd
+++ b/addons/mpf-gmc/scripts/bcp_server.gd
@@ -288,6 +288,7 @@ func _thread_poll(_userdata=null) -> void:
 	while _client:
 		# If the mutex is locked, the system is shutting down
 		if not _mutex.try_lock():
+			self.log.info("BCP poll thread exiting: mutex unavailable.")
 			return
 		var err = _client.poll()
 		if err != OK:
@@ -305,6 +306,11 @@ func _thread_poll(_userdata=null) -> void:
 
 		var bytes = _client.get_available_bytes()
 		if not bytes:
+			# Release the mutex before looping. Mutex is recursive, so skipping
+			# the unlock at the bottom of this loop leaks one lock level per
+			# idle poll instead of deadlocking, and try_lock() above fails for
+			# good once the recursion counter saturates.
+			_mutex.unlock()
 			OS.delay_msec(delay)
 			continue
 


### PR DESCRIPTION
`_thread_poll()` takes `_mutex` at the top of every iteration and releases it at the bottom, but the idle branch (`if not bytes`) continues past that unlock. `Mutex` is recursive, so this does not deadlock: it leaks one lock level per idle poll and stays invisible until the underlying recursion counter saturates. On macOS that happens at 65535, after which `try_lock()` fails permanently, the loop hits its `return`, and the BCP reader thread is gone. There is no log line, no `stop()` and no reconnect, so MPF carries on posting events into a socket nobody reads while GMC keeps rendering whatever slide it last received.

How long that takes depends on how idle the connection is, since a poll that actually reads bytes unlocks normally. At the shipped 120 Hz poll rate an idle client saturates in roughly ten minutes. The machine I found this on was sitting in attract, where nearly every poll takes the idle path, and it froze on a carousel slide while MPF was still happily rotating it. The receive queue on the GMC side of the socket grows without bound afterwards, which is the quickest way to confirm it from outside: `netstat -an -p tcp` shows Recv-Q climbing steadily while Godot itself stays responsive and keeps rendering at full frame rate.

The fix is to unlock before continuing. I also added an info log to the `try_lock()` exit, because that path returning silently is what made this present as an unexplained freeze rather than a reported error.

I confirmed both the failure and the fix with a headless test that drives the real `_thread_poll` against a connected but silent socket with the poll delay pinned to zero, so it clears the 65535 iterations in about a second. Without the patch the thread is dead by the end of the spin and no longer consumes anything sent to it; with the patch it stays alive and still answers a `reset`. No config or API changes.
